### PR TITLE
Add Python3 Compatability

### DIFF
--- a/pytmatrix/orientation.py
+++ b/pytmatrix/orientation.py
@@ -133,6 +133,9 @@ def orient_averaged_fixed(tm):
     ap = np.linspace(0, 360, tm.n_alpha+1)[:-1]
     aw = 1.0/tm.n_alpha
 
+    import orientation
+    tm.orient = orientation.orient_averaged_fixed
+    tm._init_orient()
     for alpha in ap:
         for (beta, w) in zip(tm.beta_p, tm.beta_w):
             (S_ang, Z_ang) = tm.get_SZ_single(alpha=alpha, beta=beta)

--- a/pytmatrix/orientation.py
+++ b/pytmatrix/orientation.py
@@ -133,9 +133,6 @@ def orient_averaged_fixed(tm):
     ap = np.linspace(0, 360, tm.n_alpha+1)[:-1]
     aw = 1.0/tm.n_alpha
 
-    import pytmatrix.orientation as orientation
-    tm.orient = orientation.orient_averaged_fixed
-    tm._init_orient()
     for alpha in ap:
         for (beta, w) in zip(tm.beta_p, tm.beta_w):
             (S_ang, Z_ang) = tm.get_SZ_single(alpha=alpha, beta=beta)

--- a/pytmatrix/orientation.py
+++ b/pytmatrix/orientation.py
@@ -133,7 +133,7 @@ def orient_averaged_fixed(tm):
     ap = np.linspace(0, 360, tm.n_alpha+1)[:-1]
     aw = 1.0/tm.n_alpha
 
-    import orientation
+    import pytmatrix.orientation as orientation
     tm.orient = orientation.orient_averaged_fixed
     tm._init_orient()
     for alpha in ap:

--- a/pytmatrix/psd.py
+++ b/pytmatrix/psd.py
@@ -28,7 +28,8 @@ import warnings
 import numpy as np
 from scipy.integrate import trapz
 from scipy.special import gamma
-import scatter, tmatrix_aux
+import pytmatrix.scatter as scatter
+import pytmatrix.tmatrix_aux as tmatrix_aux
 
 
 class PSD(object):

--- a/pytmatrix/quadrature/quadrature.py
+++ b/pytmatrix/quadrature/quadrature.py
@@ -33,9 +33,11 @@ def discrete_gautschi(z, w, n_iter):
     b = np.empty(n_iter)
 
     if sys.version_info[0] > 2:
-        xrange = range
+        prange = range
+    else:
+        prange = xrange
         
-    for j in xrange(n_iter):
+    for j in prange(n_iter):
         p_norm = np.dot(w*p,p)
         a[j] = np.dot(wz*p,p)/p_norm
         b[j] = 0.0 if j==0 else p_norm/np.dot(w*p_prev,p_prev)

--- a/pytmatrix/quadrature/quadrature.py
+++ b/pytmatrix/quadrature/quadrature.py
@@ -21,6 +21,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import numpy as np
 from scipy.integrate import quad
+import sys
 
 
 def discrete_gautschi(z, w, n_iter):
@@ -30,6 +31,9 @@ def discrete_gautschi(z, w, n_iter):
     wz = z*w
     a = np.empty(n_iter)
     b = np.empty(n_iter)
+
+    if sys.version_info[0] > 2:
+        xrange = range
         
     for j in xrange(n_iter):
         p_norm = np.dot(w*p,p)

--- a/pytmatrix/radar.py
+++ b/pytmatrix/radar.py
@@ -20,7 +20,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 import numpy as np
-from scatter import ldr, ext_xsect
+from pytmatrix.scatter import ldr, ext_xsect
 
 
 def radar_xsect(scatterer, h_pol=True):

--- a/pytmatrix/refractive.py
+++ b/pytmatrix/refractive.py
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from os import path
 import numpy as np
 from scipy import interpolate
-from tmatrix_aux import wl_S, wl_C, wl_X, wl_Ku, wl_Ka, wl_W
+from pytmatrix.tmatrix_aux import wl_S, wl_C, wl_X, wl_Ku, wl_Ka, wl_W
 
 
 def mg_refractive(m, mix):

--- a/pytmatrix/test/test_tmatrix.py
+++ b/pytmatrix/test/test_tmatrix.py
@@ -21,14 +21,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import unittest
 import numpy as np
-from ..tmatrix import TMatrix, Scatterer
-from ..tmatrix_psd import TMatrixPSD
-from .. import orientation
-from .. import radar
-from .. import refractive
-from .. import tmatrix_aux
-from .. import psd
-from .. import scatter
+from pytmatrix.tmatrix import TMatrix, Scatterer
+from pytmatrix.tmatrix_psd import TMatrixPSD
+from pytmatrix import orientation
+from pytmatrix import radar
+from pytmatrix import refractive
+from pytmatrix import tmatrix_aux
+from pytmatrix import psd
+from pytmatrix import scatter
 
 
 #some allowance for rounding errors etc

--- a/pytmatrix/test/test_tmatrix.py
+++ b/pytmatrix/test/test_tmatrix.py
@@ -62,10 +62,10 @@ def test_backend():
     scatterer.alpha = 145.0
     scatterer.beta = 52.0
         
-    print "Amplitude matrix S:"
-    print scatterer.get_S()
-    print "Phase matrix Z:"
-    print scatterer.get_Z()
+    print("Amplitude matrix S:")
+    print(scatterer.get_S())
+    print("Phase matrix Z:")
+    print(scatterer.get_Z())
 
 
 class TMatrixTests(unittest.TestCase):

--- a/pytmatrix/tmatrix.py
+++ b/pytmatrix/tmatrix.py
@@ -21,9 +21,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import warnings
 import numpy as np
-from fortran_tm import pytmatrix
-from quadrature import quadrature
-import orientation
+from pytmatrix.fortran_tm import pytmatrix
+from pytmatrix.quadrature import quadrature
+import pytmatrix.orientation as orientation
 
 
 

--- a/pytmatrix/tmatrix_psd.py
+++ b/pytmatrix/tmatrix_psd.py
@@ -20,9 +20,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 import warnings
-from tmatrix import Scatterer
-from psd import PSDIntegrator, GammaPSD, BinnedPSD
-import tmatrix_aux
+from pytmatrix.tmatrix import Scatterer
+from pytmatrix.psd import PSDIntegrator, GammaPSD, BinnedPSD
+import pytmatrix.tmatrix_aux as tmatrix_aux
 
 
 class TMatrixPSD(Scatterer):


### PR DESCRIPTION
I've made some minor changes to support python3. 

1) Added parentheses to print states, since print statements are now the print function
2) Switched the imports from relative to absolute, since python3 handles relative imports differently
3) Dyanmically switched between xrange and range in python versions 2 and 3, since they are the same.

All of the unit tests still pass under python2.7 and python3. I don't have a python2.6 install available, but none of the changes should be incompatible.