### PR TITLE
check for None for python3 compatibility

### DIFF
--- a/pytmatrix/psd.py
+++ b/pytmatrix/psd.py
@@ -240,6 +240,10 @@ class BinnedPSD(PSD):
             return np.array([self.psd_for_D(d) for d in D])
     
     def __eq__(self, other):
+        if self is None or other is None:
+            if self is None and other is None:
+                return True
+            return False
         return len(self.bin_edges) == len(other.bin_edges) and \
             (self.bin_edges == other.bin_edges).all() and \
             (self.bin_psd == other.bin_psd).all()


### PR DESCRIPTION
Tried using this code on python3. This is a fix for the error I found while trying to generate radar parameters using binned psd data.