### PR TITLE
Check for None for python 3 compatibility

### DIFF
--- a/pytmatrix/psd.py
+++ b/pytmatrix/psd.py
@@ -240,6 +240,10 @@ class BinnedPSD(PSD):
             return np.array([self.psd_for_D(d) for d in D])
     
     def __eq__(self, other):
+        if self is None or other is None:
+            if self is None and other is None:
+                return True
+            return False
         return len(self.bin_edges) == len(other.bin_edges) and \
             (self.bin_edges == other.bin_edges).all() and \
             (self.bin_psd == other.bin_psd).all()

--- a/pytmatrix/psd.py
+++ b/pytmatrix/psd.py
@@ -241,9 +241,7 @@ class BinnedPSD(PSD):
     
     def __eq__(self, other):
         if self is None or other is None:
-            if self is None and other is None:
-                return True
-            return False
+            return self is None and other is None
         return len(self.bin_edges) == len(other.bin_edges) and \
             (self.bin_edges == other.bin_edges).all() and \
             (self.bin_psd == other.bin_psd).all()

--- a/pytmatrix/psd.py
+++ b/pytmatrix/psd.py
@@ -240,8 +240,8 @@ class BinnedPSD(PSD):
             return np.array([self.psd_for_D(d) for d in D])
     
     def __eq__(self, other):
-        if self is None or other is None:
-            return self is None and other is None
+        if other is None:
+            return False
         return len(self.bin_edges) == len(other.bin_edges) and \
             (self.bin_edges == other.bin_edges).all() and \
             (self.bin_psd == other.bin_psd).all()


### PR DESCRIPTION
Using the binned psd seems to be working in python 3 after this fix.