### PR TITLE
fix conversion from max radius to equi-vol radius for prolate shapes

### DIFF
--- a/pytmatrix/tmatrix.py
+++ b/pytmatrix/tmatrix.py
@@ -249,12 +249,12 @@ class Scatterer(object):
             if self.axis_ratio > 1.0: # oblate
                 r_eq = self.radius/self.axis_ratio**(1.0/3.0)
             else: # prolate
-                r_eq = self.radius/self.axis_ratio**(2.0/3.0)
+                r_eq = self.radius*self.axis_ratio**(2.0/3.0)
         elif self.shape == Scatterer.SHAPE_CYLINDER:
             if self.axis_ratio > 1.0: # oblate
                 r_eq = self.radius*(0.75/self.axis_ratio)**(1.0/3.0)
             else: # prolate
-                r_eq = self.radius*(0.75/self.axis_ratio)**(2.0/3.0)
+                r_eq = self.radius*(0.75*self.axis_ratio)**(2.0/3.0)
         else:
             raise AttributeError("Unsupported shape for maximum radius.")
         return r_eq


### PR DESCRIPTION
Hi Jussi,
I believe there is a bug in the formula that converts the maximum radius to the equivalent volume radius when the shape is prolate.
The thing is that for prolate particles the maximum dimension becomes the rotational axis of the spheroid (cylinder) which means that the horizontal axes are Dmax*ar when ar is defined as horizontal/rotational axis length.
all the best
D